### PR TITLE
genny.run has two arguments, the first one is undefined and the second one is resume object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,5 +232,8 @@ exports.middleware = function(gen) {
 }
 
 exports.run = function(gen, cb) {
-    exports.fn(gen)(cb);
+    if(co)
+        exports.fn(gen)(cb);
+    else
+        exports.fn(gen)();
 }


### PR DESCRIPTION
When I tried genny.run I noticed the first argument was undefined and the second argument was resume object.
I think this is not expected.
